### PR TITLE
GH-38879: [C++][Gandiva] Fix Gandiva to_date function's validation for supress errors parameter

### DIFF
--- a/cpp/src/gandiva/to_date_holder.cc
+++ b/cpp/src/gandiva/to_date_holder.cc
@@ -50,7 +50,7 @@ Result<std::shared_ptr<ToDateHolder>> ToDateHolder::Make(const FunctionNode& nod
   if (node.children().size() == 3) {
     auto literal_suppress_errors =
         dynamic_cast<LiteralNode*>(node.children().at(2).get());
-    if (literal_pattern == nullptr) {
+    if (literal_suppress_errors == nullptr) {
       return Status::Invalid(
           "The (optional) third parameter to 'to_date' function needs to an integer "
           "literal to indicate whether to suppress the error");


### PR DESCRIPTION
### Rationale for this change
* This PR fixes the `to_date_utf8_utf8_int32` gandiva function to avoid crash for invalid input

### What changes are included in this PR?
* A bug fix for to_date_utf8_utf8_int32 parameter validation

### Are these changes tested?
Yes, new tests are added to verify non literal input won't crash the to_date_utf8_utf8_int32 function

### Are there any user-facing changes?
No
* Closes: #38879